### PR TITLE
Tizo/improve table performance

### DIFF
--- a/Server/Server/Controllers/ActivityController.cs
+++ b/Server/Server/Controllers/ActivityController.cs
@@ -46,29 +46,27 @@ namespace Server.Controllers
                     query = query.Where(a => a.Status == status.Value);
 
                 var totalCount = await query.CountAsync();
-                
-                var activityEntities = await query
-                    .Include(a => a.SensorDataPackets)
+
+                var activities = await query
                     .OrderByDescending(a => a.StartTime)
                     .Skip((page - 1) * pageSize)
                     .Take(pageSize)
+                    .Select(a => new ActivityResponse
+                    {
+                        Id = a.Id,
+                        Name = a.Name,
+                        Description = a.Description,
+                        StartTime = a.StartTime,
+                        EndTime = a.EndTime,
+                        Status = a.Status,
+                        Duration = a.EndTime.HasValue ? a.EndTime.Value - a.StartTime : null,
+                        IsActive = a.Status == ActivityStatus.InProgress,
+                        DataPacketCount = a.SensorDataPackets.Count,
+                        CreatedAt = a.CreatedAt,
+                        UpdatedAt = a.UpdatedAt,
+                        Analytics = null 
+                    })
                     .ToListAsync();
-
-                var activities = activityEntities.Select(a => new ActivityResponse
-                {
-                    Id = a.Id,
-                    Name = a.Name,
-                    Description = a.Description,
-                    StartTime = a.StartTime,
-                    EndTime = a.EndTime,
-                    Status = a.Status,
-                    Duration = a.EndTime.HasValue ? a.EndTime.Value - a.StartTime : null,
-                    IsActive = a.Status == ActivityStatus.InProgress,
-                    DataPacketCount = a.SensorDataPackets.Count,
-                    CreatedAt = a.CreatedAt,
-                    UpdatedAt = a.UpdatedAt,
-                    Analytics = CalculateAnalytics(a.SensorDataPackets.OrderBy(s => s.Timestamp).ToList())
-                }).ToList();
 
                 return Ok(new ActivityListResponse
                 {
@@ -121,7 +119,7 @@ namespace Server.Controllers
                     DataPacketCount = activity.DataPacketCount,
                     CreatedAt = activity.CreatedAt,
                     UpdatedAt = activity.UpdatedAt,
-                    Analytics = CalculateAnalytics(activity.SensorDataPackets.ToList())
+                    Analytics = GetAnalytics(activity)
                 };
 
                 var sensorData = activity.SensorDataPackets.Select(s => new SensorDataPacketResponse
@@ -449,7 +447,7 @@ namespace Server.Controllers
                     DataPacketCount = activity.DataPacketCount,
                     CreatedAt = activity.CreatedAt,
                     UpdatedAt = activity.UpdatedAt,
-                    Analytics = CalculateAnalytics(packets)
+                    Analytics = GetAnalytics(activity)
                 };
 
                 return Ok(ApiResponse<ActivityResponse>.Success(response, "Seed activity created"));
@@ -496,7 +494,7 @@ namespace Server.Controllers
                     double totalDistance = 0;
                     foreach (var activity in dayActivities)
                     {
-                        var analytics = CalculateAnalytics(activity.SensorDataPackets.OrderBy(s => s.Timestamp).ToList());
+                        var analytics = GetAnalytics(activity);
                         totalDistance += analytics.TotalDistance;
                     }
 
@@ -552,7 +550,7 @@ namespace Server.Controllers
                 var currentElevation = 0.0;
                 foreach (var a in currentWeekActivities)
                 {
-                    var analytics = CalculateAnalytics(a.SensorDataPackets.ToList());
+                    var analytics = GetAnalytics(a);
                     currentDistance += analytics.TotalDistance / 1000;
                     currentElevation += analytics.ElevationGain;
                 }
@@ -564,7 +562,7 @@ namespace Server.Controllers
                 var previousElevation = 0.0;
                 foreach (var a in previousWeekActivities)
                 {
-                    var analytics = CalculateAnalytics(a.SensorDataPackets.ToList());
+                    var analytics = GetAnalytics(a);
                     previousDistance += analytics.TotalDistance / 1000;
                     previousElevation += analytics.ElevationGain;
                 }
@@ -726,53 +724,22 @@ namespace Server.Controllers
             return long.TryParse(userIdClaim, out var userId) ? userId : null;
         }
 
-        private ActivityAnalytics CalculateAnalytics(List<SensorDataPacket> sensorData)
+        private ActivityAnalytics GetAnalytics(Activity activity)
         {
-            if (!sensorData.Any())
+            if (activity.Summary == null)
                 return new ActivityAnalytics();
 
-            var analytics = new ActivityAnalytics
+            return new ActivityAnalytics
             {
-                MaxSpeed = sensorData.Max(s => s.CurrentSpeed),
-                AverageSpeed = sensorData.Average(s => s.CurrentSpeed),
-                AverageTemperature = sensorData.Average(s => s.CurrentTemperature),
-                MaxAcceleration = sensorData.Max(s => s.TotalAcceleration),
-                Route = sensorData.Select(s => new CoordinatePoint
-                {
-                    Latitude = s.Latitude,
-                    Longitude = s.Longitude,
-                    Timestamp = s.Timestamp,
-                    Speed = s.CurrentSpeed,
-                    Temperature = s.CurrentTemperature
-                }).ToList()
+                TotalDistance = activity.Summary.TotalDistanceMeters,
+                MaxSpeed = activity.Summary.MaxSpeedKmh,
+                AverageSpeed = activity.Summary.AverageSpeedKmh,
+                ElevationGain = activity.Summary.ElevationGainMeters ?? 0,
+                CaloriesBurned = activity.Summary.EstimatedCaloriesBurned,
+                AverageTemperature = activity.Summary.AverageTemperatureCelsius,
+                MaxAcceleration = activity.Summary.MaxAccelerationMs2,
+                Route = new List<CoordinatePoint>() // only populate route in detail endpoint
             };
-
-            // Calculate total distance using Haversine formula
-            analytics.TotalDistance = CalculateTotalDistance(analytics.Route);
-
-            // Simple calorie calculation (can be improved with more sophisticated algorithms)
-            var durationHours = sensorData.Count > 0 ? 
-                (sensorData.Max(s => s.Timestamp) - sensorData.Min(s => s.Timestamp)).TotalHours : 0;
-            analytics.CaloriesBurned = analytics.AverageSpeed * durationHours * 50; // Rough estimation
-
-            // Calculate elevation gain (would need altitude data from GPS or barometric sensor)
-            analytics.ElevationGain = sensorData.Max(s => s.CurrentElevation) -  sensorData.Min(s => s.CurrentElevation);
-
-            return analytics;
-        }
-
-        private double CalculateTotalDistance(List<CoordinatePoint> route)
-        {
-            if (route.Count < 2) return 0;
-
-            double totalDistance = 0;
-            for (int i = 1; i < route.Count; i++)
-            {
-                totalDistance += CalculateDistance(
-                    route[i - 1].Latitude, route[i - 1].Longitude,
-                    route[i].Latitude, route[i].Longitude);
-            }
-            return totalDistance;
         }
         
         private double CalculateTotalTime(List<Activity> activities)
@@ -810,19 +777,6 @@ namespace Server.Controllers
             var wholeHours = (int)hours;
             var minutes = (int)((hours - wholeHours) * 60);
             return $"{wholeHours}:{minutes:D2}h";
-        }
-
-        private double CalculateDistance(double lat1, double lon1, double lat2, double lon2)
-        {
-            // Haversine formula
-            const double R = 6371000; // Earth's radius in meters
-            var dLat = (lat2 - lat1) * Math.PI / 180;
-            var dLon = (lon2 - lon1) * Math.PI / 180;
-            var a = Math.Sin(dLat / 2) * Math.Sin(dLat / 2) +
-                    Math.Cos(lat1 * Math.PI / 180) * Math.Cos(lat2 * Math.PI / 180) *
-                    Math.Sin(dLon / 2) * Math.Sin(dLon / 2);
-            var c = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
-            return R * c;
         }
     }
 }

--- a/Server/Server/Controllers/ActivityController.cs
+++ b/Server/Server/Controllers/ActivityController.cs
@@ -483,7 +483,7 @@ namespace Server.Controllers
 
                 // Get all completed activities for the week
                 var activities = await _context.Activities
-                    .Include(a => a.SensorDataPackets)
+                    .Include(a => a.Summary)
                     .Where(a => a.UserId == userId.Value && 
                                 a.Status == ActivityStatus.Completed &&
                                 a.StartTime >= weekStart && 

--- a/Server/Server/Controllers/ActivityController.cs
+++ b/Server/Server/Controllers/ActivityController.cs
@@ -536,7 +536,7 @@ namespace Server.Controllers
 
                 // Gget activities for current and previous week 
                 var currentWeekActivities = await _context.Activities
-                    .Include(a => a.SensorDataPackets)
+                    .Include(a => a.Summary)
                     .Where(a => a.UserId == userId.Value && 
                                a.Status == ActivityStatus.Completed &&
                                a.StartTime >= currentWeekStart && 
@@ -544,7 +544,7 @@ namespace Server.Controllers
                     .ToListAsync();
 
                 var previousWeekActivities = await _context.Activities
-                    .Include(a => a.SensorDataPackets)
+                    .Include(a => a.Summary)
                     .Where(a => a.UserId == userId.Value && 
                                a.Status == ActivityStatus.Completed &&
                                a.StartTime >= previousWeekStart && 
@@ -554,27 +554,15 @@ namespace Server.Controllers
                 // calculate current week stats
                 var currentActivityCount = currentWeekActivities.Count;
                 var currentTime = CalculateTotalTime(currentWeekActivities);
-                var currentDistance = 0.0;
-                var currentElevation = 0.0;
-                foreach (var a in currentWeekActivities)
-                {
-                    var analytics = GetAnalytics(a);
-                    currentDistance += analytics.TotalDistance / 1000;
-                    currentElevation += analytics.ElevationGain;
-                }
+                var currentDistance = currentWeekActivities.Sum(a => (a.Summary?.TotalDistanceMeters ?? 0) / 1000.0);
+                var currentElevation = currentWeekActivities.Sum(a => a.Summary?.ElevationGainMeters ?? 0);
 
                 // calculate previous week stats
                 var previousActivityCount = previousWeekActivities.Count;
                 var previousTime = CalculateTotalTime(previousWeekActivities);
-                var previousDistance = 0.0;
-                var previousElevation = 0.0;
-                foreach (var a in previousWeekActivities)
-                {
-                    var analytics = GetAnalytics(a);
-                    previousDistance += analytics.TotalDistance / 1000;
-                    previousElevation += analytics.ElevationGain;
-                }
-
+                var previousDistance = previousWeekActivities.Sum(a => (a.Summary?.TotalDistanceMeters ?? 0) / 1000.0);
+                var previousElevation = previousWeekActivities.Sum(a => a.Summary?.ElevationGainMeters ?? 0);
+                
                 var response = new KpiDataResponse
                 {
                     ActivityCount = currentActivityCount.ToString(),

--- a/Server/Server/Controllers/ActivityController.cs
+++ b/Server/Server/Controllers/ActivityController.cs
@@ -40,33 +40,34 @@ namespace Server.Controllers
                     return Unauthorized(new ActivityListResponse { IsSuccess = false, Message = "User not found" });
 
                 var query = _context.Activities
-                    .Where(a => a.UserId == userId.Value);
+                    .Where(a => a.UserId == userId.Value)
+                    .Include(a => a.Summary)
+                    .OrderByDescending(a => a.StartTime)
+                    .Skip((page - 1) * pageSize)
+                    .Take(pageSize);
 
                 if (status.HasValue)
                     query = query.Where(a => a.Status == status.Value);
 
                 var totalCount = await query.CountAsync();
-
-                var activities = await query
-                    .OrderByDescending(a => a.StartTime)
-                    .Skip((page - 1) * pageSize)
-                    .Take(pageSize)
-                    .Select(a => new ActivityResponse
-                    {
-                        Id = a.Id,
-                        Name = a.Name,
-                        Description = a.Description,
-                        StartTime = a.StartTime,
-                        EndTime = a.EndTime,
-                        Status = a.Status,
-                        Duration = a.EndTime.HasValue ? a.EndTime.Value - a.StartTime : null,
-                        IsActive = a.Status == ActivityStatus.InProgress,
-                        DataPacketCount = a.SensorDataPackets.Count,
-                        CreatedAt = a.CreatedAt,
-                        UpdatedAt = a.UpdatedAt,
-                        Analytics = null 
-                    })
-                    .ToListAsync();
+                
+                var activityEntities = await query.ToListAsync();
+                
+                var activities = activityEntities.Select(a => new ActivityResponse
+                {
+                    Id = a.Id,
+                    Name = a.Name,
+                    Description = a.Description,
+                    StartTime = a.StartTime,
+                    EndTime = a.EndTime,
+                    Status = a.Status,
+                    Duration = a.EndTime.HasValue ? a.EndTime.Value - a.StartTime : null,
+                    IsActive = a.Status == ActivityStatus.InProgress,
+                    DataPacketCount = a.SensorDataPackets.Count,
+                    CreatedAt = a.CreatedAt,
+                    UpdatedAt = a.UpdatedAt,
+                    Analytics = GetAnalytics(a)
+                }).ToList();
 
                 return Ok(new ActivityListResponse
                 {
@@ -100,7 +101,7 @@ namespace Server.Controllers
                     return Unauthorized(new ActivityDetailsResponse { IsSuccess = false, Message = "User not found" });
 
                 var activity = await _context.Activities
-                    .Include(a => a.SensorDataPackets.OrderBy(s => s.Timestamp))
+                    .Include(a => a.Summary)
                     .FirstOrDefaultAsync(a => a.Id == id && a.UserId == userId.Value);
 
                 if (activity == null)
@@ -121,8 +122,13 @@ namespace Server.Controllers
                     UpdatedAt = activity.UpdatedAt,
                     Analytics = GetAnalytics(activity)
                 };
-
-                var sensorData = activity.SensorDataPackets.Select(s => new SensorDataPacketResponse
+                
+                var packets = await _context.SensorDataPackets
+                    .Where(p => p.ActivityId == activity.Id)
+                    .OrderBy(p => p.Timestamp)
+                    .ToListAsync();
+                
+                var sensorData = packets.Select(s => new SensorDataPacketResponse
                 {
                     Id = s.Id,
                     ActivityId = s.ActivityId,
@@ -432,6 +438,8 @@ namespace Server.Controllers
                 activity.EndTime = packets.Count > 0 ? packets[^1].Timestamp : startTime.AddMinutes(5);
                 activity.Status = ActivityStatus.Completed;
                 activity.UpdatedAt = DateTime.UtcNow;
+                var summary = SensorDataController.BuildSummaryFromPackets(activity, packets);
+                activity.Summary = summary;
                 await _context.SaveChangesAsync();
 
                 var response = new ActivityResponse
@@ -727,7 +735,9 @@ namespace Server.Controllers
         private ActivityAnalytics GetAnalytics(Activity activity)
         {
             if (activity.Summary == null)
+            {
                 return new ActivityAnalytics();
+            }
 
             return new ActivityAnalytics
             {

--- a/Server/Server/Controllers/SensorDataController.cs
+++ b/Server/Server/Controllers/SensorDataController.cs
@@ -58,6 +58,11 @@ namespace Server.Controllers
                 activity.Status = ActivityStatus.Completed;
                 activity.UpdatedAt = DateTime.UtcNow;
 
+                // build summary from existing packets
+                var packets = activity.SensorDataPackets.OrderBy(p => p.Timestamp).ToList();
+                var summary = BuildSummaryFromPackets(activity, packets);
+                activity.Summary = summary;
+                
                 _context.Activities.Update(activity);
                 await _context.SaveChangesAsync();
 
@@ -244,6 +249,81 @@ namespace Server.Controllers
                 _logger.LogError(ex, "Error creating activity for device {DeviceId}", deviceId);
                 return null;
             }
+        }
+
+        private ActivitySummary BuildSummaryFromPackets(Activity activity, List<SensorDataPacket> packets)
+        {
+            var summary = new ActivitySummary
+            {
+                ActivityId = activity.Id,
+                TotalDataPackets = packets.Count,
+                ValidDataPackets = packets.Count(p => p.IsChecksumValid),
+                DataQualityPercentage = packets.Count == 0 ? 0 : 
+                    (double)packets.Count(p => p.IsChecksumValid) / packets.Count * 100.0,
+                CalculatedAt = DateTime.UtcNow,
+                IsStale = false,
+            };
+            
+            if (packets.Count == 0)
+                return summary;
+            
+            // temperature
+            summary.AverageTemperatureCelsius = packets.Average(p => p.CurrentTemperature);
+            summary.MinTemperatureCelsius = packets.Min(p => p.CurrentTemperature);
+            summary.MaxTemperatureCelsius = packets.Max(p => p.CurrentTemperature);
+
+            // speed
+            summary.MaxSpeedKmh = packets.Max(p => p.CurrentSpeed) * 3.6;
+            summary.AverageSpeedKmh = packets.Average(p => p.CurrentSpeed) * 3.6;
+
+            // acceleration 
+            summary.MaxAccelerationMs2 = packets.Max(p => p.TotalAcceleration);
+            summary.AverageAccelerationMs2 = packets.Average(p => p.TotalAcceleration);
+            
+            // distance calculation
+            double totalMeters = 0;
+            for (int i = 1; i < packets.Count; i++)
+            {
+                totalMeters += CalculateDistance(
+                    packets[i - 1].Latitude, packets[i - 1].Longitude,
+                    packets[i].Latitude, packets[i].Longitude);
+            }
+            summary.TotalDistanceMeters = totalMeters;
+            
+            // elevation with CurrentElevation
+            summary.MaxElevationMeters = packets.Max(p => p.CurrentElevation);
+            summary.MinElevationMeters = packets.Min(p => p.CurrentElevation);
+            summary.ElevationGainMeters = summary.MaxElevationMeters - summary.MinElevationMeters;
+
+            // durations
+            summary.TotalDuration = (activity.EndTime ?? packets.Last().Timestamp) - activity.StartTime;
+            summary.ActiveDuration = summary.TotalDuration;
+
+            // calories
+            summary.CalculateEstimatedCalories();
+
+            // route start/end
+            var first = packets.First();
+            var last = packets.Last();
+            summary.StartLatitude = first.Latitude;
+            summary.StartLongitude = first.Longitude;
+            summary.EndLatitude = last.Latitude;
+            summary.EndLongitude = last.Longitude;
+
+            return summary;
+        }
+        
+        private double CalculateDistance(double lat1, double lon1, double lat2, double lon2)
+        {
+            // Haversine formula
+            const double R = 6371000; // Earth's radius in meters
+            var dLat = (lat2 - lat1) * Math.PI / 180;
+            var dLon = (lon2 - lon1) * Math.PI / 180;
+            var a = Math.Sin(dLat / 2) * Math.Sin(dLat / 2) +
+                    Math.Cos(lat1 * Math.PI / 180) * Math.Cos(lat2 * Math.PI / 180) *
+                    Math.Sin(dLon / 2) * Math.Sin(dLon / 2);
+            var c = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+            return R * c;
         }
     }
 }

--- a/Server/Server/Controllers/SensorDataController.cs
+++ b/Server/Server/Controllers/SensorDataController.cs
@@ -59,7 +59,10 @@ namespace Server.Controllers
                 activity.UpdatedAt = DateTime.UtcNow;
 
                 // build summary from existing packets
-                var packets = activity.SensorDataPackets.OrderBy(p => p.Timestamp).ToList();
+                var packets = await _context.SensorDataPackets
+                    .Where(p => p.ActivityId == activity.Id)
+                    .OrderBy(p => p.Timestamp)
+                    .ToListAsync();
                 var summary = BuildSummaryFromPackets(activity, packets);
                 activity.Summary = summary;
                 
@@ -251,7 +254,7 @@ namespace Server.Controllers
             }
         }
 
-        private ActivitySummary BuildSummaryFromPackets(Activity activity, List<SensorDataPacket> packets)
+        public static ActivitySummary BuildSummaryFromPackets(Activity activity, List<SensorDataPacket> packets)
         {
             var summary = new ActivitySummary
             {
@@ -313,7 +316,7 @@ namespace Server.Controllers
             return summary;
         }
         
-        private double CalculateDistance(double lat1, double lon1, double lat2, double lon2)
+        private static double CalculateDistance(double lat1, double lon1, double lat2, double lon2)
         {
             // Haversine formula
             const double R = 6371000; // Earth's radius in meters


### PR DESCRIPTION
moved the calculation of activity summary data to end of activity (implemented for real activities, test data needs to access method from sensor data controller to calculate analytics) need for activity analytics calculation is removed from requests. summary contains all the data. sensor data packets don't need to be included in the request -> saving a lot of time